### PR TITLE
Made workflow comparison and fix branch-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,16 @@ This GitHub Action enforces the Ship Every Merge standards on Trilogy products.
 * For an existing project, copy [engineering-standards.yml](https://github.com/trilogy-group/eng-template/raw/main/.github/workflows/engineering-standards.yml) into your repository under .github/workflows/
 
 # Pipeline
-GitHub Actions require the built artefacts to appear in the repository.
+GitHub Actions require the built artifacts to appear in the repository.
 The process is:
 * Commit to main
 * Continuous flow action triggers
 * Project is built and packaged
 * Release artefacts appear under the repo tag latest
 * Projects refer to this repository as **trilogy-group/eng-standard@latest**
+
+# Permissions
+
+This action requires an admin token from Github in order to fix the found issues automatically. The image below illustrates these permissions - please apply them carefully to prevent hard-to-track permission issues:
+
+<img width="774" alt="Github Action necessary permissions" src="https://user-images.githubusercontent.com/10912950/108193493-43fe4300-70f4-11eb-880c-611ca44cf4ce.png">

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This GitHub Action enforces the Ship Every Merge standards on Trilogy products.
 * For an existing project, copy [engineering-standards.yml](https://github.com/trilogy-group/eng-template/raw/main/.github/workflows/engineering-standards.yml) into your repository under .github/workflows/
 
 # Pipeline
-GitHub Actions require the built artifacts to appear in the repository.
+GitHub Actions require the built artefacts to appear in the repository.
 The process is:
 * Commit to main
 * Continuous flow action triggers

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'Repository name with owner. For example, trilogy-group/sococo'
     default: ${{ github.repository }}
     required: false
+  branch:
+    description: 'The full name (e.g. refs/heads/branch) of the target branch'
+    default: ${GITHUB_REF}
+    required: false
   repair:
     description: 'Repair issues that we can'
     default: "true"

--- a/src/ComplianceChecker.ts
+++ b/src/ComplianceChecker.ts
@@ -16,13 +16,12 @@ export class ComplianceChecker {
         @inject('rules') private readonly rules: Rule[],
         private readonly productService: ProductService
     ) {
-        this.rules = rules;
-        this.productService = productService;
     }
 
     async main() {
         const doRepair = process.env.INPUT_REPAIR == 'true';
-        let product = await this.productService.loadProduct();
+        const branch = String(process.env.INPUT_BRANCH);
+        let product = await this.productService.loadProduct(branch);
 
         let passing = true;
         for(const rule of this.rules) {
@@ -54,7 +53,7 @@ export class ComplianceChecker {
                     if (attempt == 0 && outcome != RESULT_PASS && doRepair && fixFunc) {
                         try {
                             await fixFunc.call(rule, product);
-                            product = await this.productService.loadProduct();
+                            product = await this.productService.loadProduct(branch);
                             outcome = null;
                             message = null;
                         } catch (repairError) {

--- a/src/Rule.ts
+++ b/src/Rule.ts
@@ -47,8 +47,8 @@ export abstract class Rule {
             path: workflowFilePath,
             ref: product.branch
         })
-        .then(response => response.data)
-        .catch(_ => null);
+            .then(response => response.data)
+            .catch(_ => null);
 
         // update the workflow file
         await this.updateFile({
@@ -71,7 +71,7 @@ export abstract class Rule {
             owner: options.product.repo.owner,
             repo: options.product.repo.name,
             message: `Update to Engineering Standards`,
-            path: encodeURIComponent(options.path),
+            path: options.path,
             content: Buffer.from(options.content).toString('base64'),
             sha: options.sha,
             branch: options.product.branch

--- a/src/Rule.ts
+++ b/src/Rule.ts
@@ -7,13 +7,11 @@ import assert from "assert";
 export abstract class Rule {
 
     abstract readonly id: string;
-    readonly repair: boolean;
+    readonly repair = process.env.repair == 'true';
 
     constructor(
         protected readonly octokit: Octokit
     ) {
-        this.octokit = octokit;
-        this.repair = process.env.repair == 'true';
     }
 
     async requireWorkflow(product: Product, workflowFileName: string): Promise<void> {
@@ -27,7 +25,8 @@ export abstract class Rule {
         const workflowFile:any = await this.octokit.repos.getContent({
             owner: product.repo.owner,
             repo: product.repo.name,
-            path: workflowFilePath
+            path: workflowFilePath,
+            ref: product.branch
         }).then(response => response.data);
         const workflowContent = Buffer.from(workflowFile.content, 'base64').toString('utf8');
         const templateContent = this.getTemplateFileContent(workflowFilePath);
@@ -45,8 +44,10 @@ export abstract class Rule {
         const workflowFile:any = await this.octokit.repos.getContent({
             owner: product.repo.owner,
             repo: product.repo.name,
-            path: workflowFilePath
-        }).then(response => response.data)
+            path: workflowFilePath,
+            ref: product.branch
+        })
+        .then(response => response.data)
         .catch(_ => null);
 
         // update the workflow file
@@ -72,7 +73,8 @@ export abstract class Rule {
             message: `Update to Engineering Standards`,
             path: encodeURIComponent(options.path),
             content: Buffer.from(options.content).toString('base64'),
-            sha: options.sha
+            sha: options.sha,
+            branch: options.product.branch
         });
     }
 

--- a/src/model/Product.ts
+++ b/src/model/Product.ts
@@ -3,9 +3,9 @@ import { Repo } from "./Repo";
 export class Product {
 
     constructor(
-        readonly repo: Repo
+        readonly repo: Repo,
+        readonly branch: string
     ) {
-        this.repo = repo;
     }
 
     toString(): string {

--- a/src/rules/MainIsAlwaysReleasable.ts
+++ b/src/rules/MainIsAlwaysReleasable.ts
@@ -61,7 +61,7 @@ export class MainIsAlwaysReleasable extends Rule {
             mediaType: { previews: [ 'luke-cage' ] },
             owner: product.repo.owner,
             repo: product.repo.name,
-            branch: 'main',
+            branch: 'refs/heads/main',
             required_status_checks: {
                 strict: true,
                 contexts: [

--- a/src/services/ProductService.ts
+++ b/src/services/ProductService.ts
@@ -11,11 +11,11 @@ export class ProductService {
         this.gitHubService = gitHubService;
     }
 
-    async loadProduct(): Promise<Product> {
+    async loadProduct(branch: string): Promise<Product> {
         return Promise.all([
             this.gitHubService.loadRepository()
         ]).then(([ repo ]) =>
-            new Product(repo)
+            new Product(repo, branch)
         );
     }
 


### PR DESCRIPTION
- Added the `branch` input parameter, that grabs the `$GITHUB_REF` env var by default
- Added the `branch` parameter to the `Product` entity and the `ProductService.loadProduct` method, keeping the information about the target branch
- Removed some unnecessary bindings from the constructor's body where [parameter properties](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties) were utilized